### PR TITLE
fixes #4 Command generation issue with configs

### DIFF
--- a/imhotep_pylint/plugin.py
+++ b/imhotep_pylint/plugin.py
@@ -5,7 +5,6 @@ import re
 class PyLint(Tool):
     response_format = re.compile(r'(?P<filename>.*):(?P<line_num>\d+):'
                                  '(?P<message>.*)')
-    pylintrc_filename = '.pylintrc'
 
     configs = ('.pylintrc', 'pylintrc')
 
@@ -29,8 +28,8 @@ class PyLint(Tool):
     def get_command(self, dirname, **kwargs):
         cmd = 'pylint --output-format=parseable -rn'
         for config in self.configs:
-            if os.path.exists(os.path.join(dirname, self.pylintrc_filename)):
+            if os.path.exists(os.path.join(dirname, config)):
                 cmd += " --rcfile=%s" % os.path.join(
-                    dirname, self.pylintrc_filename)
-                continue
+                    dirname, config)
+                break
         return cmd


### PR DESCRIPTION
In plugin.py

We have two lines like this:
```python
    pylintrc_filename = '.pylintrc'
    configs = ('.pylintrc', 'pylintrc')
```

Then later you're doing this:

```python
        for config in self.configs:
            if os.path.exists(os.path.join(dirname, self.pylintrc_filename)):
                cmd += " --rcfile=%s" % os.path.join(
                    dirname, self.pylintrc_filename)
                continue
```

The problem is, you're iterating  `('.pylintrc', 'pylintrc')` but when you check which file exists, you only check `pylintrc_filename`. So it then inserts two pylintrc config flags.